### PR TITLE
Fix missing code

### DIFF
--- a/GleeBug/Debugger.Process.Breakpoint.cpp
+++ b/GleeBug/Debugger.Process.Breakpoint.cpp
@@ -123,6 +123,7 @@ namespace GleeBug
         info.internal.hardware.slot = slot;
         info.internal.hardware.type = type;
         info.internal.hardware.size = size;
+        info.internal.hardware.enabled = true;
 
         //insert in the breakpoint map
         breakpoints.insert({ { info.type, info.address }, info });


### PR DESCRIPTION
Make `info.internal.hardware.enabled = true` when `Process::SetHardwareBreakpoint` return true